### PR TITLE
Fix and improve benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,31 +79,30 @@ using the `WithArchiverConcurrency` and `WithExtractorConcurrency` options of 1,
 goos: linux
 goarch: amd64
 pkg: github.com/saracen/fastzip
-BenchmarkArchiveStore_1-24                             2         772482855 ns/op         8962844 B/op     257183 allocs/op
-BenchmarkArchiveStandardFlate_1-24                     1        13196699393 ns/op        9586992 B/op     248114 allocs/op
-BenchmarkArchiveStandardFlate_2-24                     1        7300203038 ns/op        15313704 B/op     251330 allocs/op
-BenchmarkArchiveStandardFlate_4-24                     1        3539821258 ns/op        24525648 B/op     251646 allocs/op
-BenchmarkArchiveStandardFlate_8-24                     1        1944286406 ns/op        19624032 B/op     251541 allocs/op
-BenchmarkArchiveStandardFlate_16-24                    1        1790596744 ns/op        29944856 B/op     252091 allocs/op
-BenchmarkArchiveNonStandardFlate_1-24                  1        6247745899 ns/op        14758776 B/op     248133 allocs/op
-BenchmarkArchiveNonStandardFlate_2-24                  1        3764029513 ns/op        33551632 B/op     252126 allocs/op
-BenchmarkArchiveNonStandardFlate_4-24                  1        1854558293 ns/op        27617888 B/op     252174 allocs/op
-BenchmarkArchiveNonStandardFlate_8-24                  1        1128922279 ns/op        75541672 B/op     252550 allocs/op
-BenchmarkArchiveNonStandardFlate_16-24                 2         945668228 ns/op        90173168 B/op     252723 allocs/op
-BenchmarkExtractStore_1-24                             1        5364033610 ns/op        116324288 B/op    565157 allocs/op
-BenchmarkExtractStore_2-24                             1        2639053970 ns/op        116255864 B/op    565142 allocs/op
-BenchmarkExtractStore_4-24                             1        1708197512 ns/op        116609776 B/op    565178 allocs/op
-BenchmarkExtractStore_8-24                             2         874622744 ns/op        103196552 B/op    541182 allocs/op
-BenchmarkExtractStore_16-24                            2         687568570 ns/op        106350048 B/op    541573 allocs/op
-BenchmarkExtractStandardFlate_1-24                     1        5142607436 ns/op        116689128 B/op    565209 allocs/op
-BenchmarkExtractStandardFlate_2-24                     1        2737468656 ns/op        116357072 B/op    565158 allocs/op
-BenchmarkExtractStandardFlate_4-24                     1        1351563778 ns/op        116649904 B/op    565178 allocs/op
-BenchmarkExtractStandardFlate_8-24                     2         996574326 ns/op        103007976 B/op    541164 allocs/op
-BenchmarkExtractStandardFlate_16-24                    2         658321262 ns/op        105358128 B/op    541463 allocs/op
-BenchmarkExtractNonStandardFlate_1-24                  1        5076043375 ns/op        88775520 B/op     381157 allocs/op
-BenchmarkExtractNonStandardFlate_2-24                  1        2714489120 ns/op        89336000 B/op     384490 allocs/op
-BenchmarkExtractNonStandardFlate_4-24                  1        1702744403 ns/op        89313920 B/op     384366 allocs/op
-BenchmarkExtractNonStandardFlate_8-24                  2         976734059 ns/op        74924428 B/op     362664 allocs/op
-BenchmarkExtractNonStandardFlate_16-24                 2         662083060 ns/op        75818612 B/op     365682 allocs/op
-
+BenchmarkArchiveStore_1-24                             2         827436658 ns/op         401.87 MB/s     9432392 B/op     266281 allocs/op
+BenchmarkArchiveStandardFlate_1-24                     1        13345510211 ns/op         24.92 MB/s    11723112 B/op     257254 allocs/op
+BenchmarkArchiveStandardFlate_2-24                     1        7158552137 ns/op          46.45 MB/s    15866408 B/op     260805 allocs/op
+BenchmarkArchiveStandardFlate_4-24                     1        3748912799 ns/op          88.70 MB/s    21701080 B/op     260984 allocs/op
+BenchmarkArchiveStandardFlate_8-24                     1        1929447410 ns/op         172.34 MB/s    24345232 B/op     261216 allocs/op
+BenchmarkArchiveStandardFlate_16-24                    1        1601845052 ns/op         207.59 MB/s    27819232 B/op     261527 allocs/op
+BenchmarkArchiveNonStandardFlate_1-24                  1        6323870186 ns/op          52.58 MB/s    15162312 B/op     257225 allocs/op
+BenchmarkArchiveNonStandardFlate_2-24                  1        3974602831 ns/op          83.66 MB/s    39907560 B/op     261764 allocs/op
+BenchmarkArchiveNonStandardFlate_4-24                  1        2011674444 ns/op         165.30 MB/s    46077496 B/op     261823 allocs/op
+BenchmarkArchiveNonStandardFlate_8-24                  1        1141812959 ns/op         291.22 MB/s    64150920 B/op     261970 allocs/op
+BenchmarkArchiveNonStandardFlate_16-24                 2         900114760 ns/op         369.42 MB/s    83224376 B/op     262219 allocs/op
+BenchmarkExtractStore_1-24                             1        1533926053 ns/op         214.77 MB/s    52866536 B/op     376590 allocs/op
+BenchmarkExtractStore_2-24                             2         765725804 ns/op         430.24 MB/s    37453780 B/op     352368 allocs/op
+BenchmarkExtractStore_4-24                             3         400612015 ns/op         822.35 MB/s    32543053 B/op     344306 allocs/op
+BenchmarkExtractStore_8-24                             5         244330423 ns/op        1348.35 MB/s    28740785 B/op     337885 allocs/op
+BenchmarkExtractStore_16-24                            6         176670429 ns/op        1864.74 MB/s    27412849 B/op     336255 allocs/op
+BenchmarkExtractStandardFlate_1-24                     1        5555366310 ns/op          23.29 MB/s    116613120 B/op    574230 allocs/op
+BenchmarkExtractStandardFlate_2-24                     1        2891878658 ns/op          44.73 MB/s    117078464 B/op    574266 allocs/op
+BenchmarkExtractStandardFlate_4-24                     1        1437946901 ns/op          89.96 MB/s    117199504 B/op    574274 allocs/op
+BenchmarkExtractStandardFlate_8-24                     1        1070725688 ns/op         120.81 MB/s    117706240 B/op    574328 allocs/op
+BenchmarkExtractStandardFlate_16-24                    2         730608470 ns/op         177.06 MB/s    105287080 B/op    550492 allocs/op
+BenchmarkExtractNonStandardFlate_1-24                  1        4797270832 ns/op          26.97 MB/s    89298080 B/op     390746 allocs/op
+BenchmarkExtractNonStandardFlate_2-24                  1        2670061801 ns/op          48.45 MB/s    89585600 B/op     392432 allocs/op
+BenchmarkExtractNonStandardFlate_4-24                  1        1461367611 ns/op          88.52 MB/s    89899552 B/op     394237 allocs/op
+BenchmarkExtractNonStandardFlate_8-24                  2         839255530 ns/op         154.14 MB/s    77181004 B/op     374984 allocs/op
+BenchmarkExtractNonStandardFlate_16-24                 2         626829180 ns/op         206.37 MB/s    76094588 B/op     374289 allocs/op
 ```

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -270,8 +270,10 @@ var archiveDir = flag.String("archivedir", runtime.GOROOT(), "The directory to u
 
 func benchmarkArchiveOptions(b *testing.B, stdDeflate bool, options ...ArchiverOption) {
 	files := make(map[string]os.FileInfo)
+	size := int64(0)
 	filepath.Walk(*archiveDir, func(filename string, fi os.FileInfo, err error) error {
 		files[filename] = fi
+		size += fi.Size()
 		return nil
 	})
 
@@ -282,6 +284,7 @@ func benchmarkArchiveOptions(b *testing.B, stdDeflate bool, options ...ArchiverO
 	options = append(options, WithStageDirectory(dir))
 
 	b.ReportAllocs()
+	b.SetBytes(size)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		f, err := os.Create(filepath.Join(dir, "fastzip-benchmark.zip"))


### PR DESCRIPTION
ExtractStore benchmarks were previously incorrect. A compressed archive was still being extracted.

Benchmarks now show MB/s.