### PR TITLE
Use github.com/klauspost/compress/flate by default

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -26,6 +26,8 @@ var bufioReaderPool = sync.Pool{
 	},
 }
 
+var defaultCompressor = FlateCompressor(-1)
+
 // Archiver is an opinionated Zip archiver.
 //
 // Only regular files, symlinks and directories are supported. Only files that
@@ -67,8 +69,8 @@ func NewArchiver(w io.Writer, chroot string, opts ...ArchiverOption) (*Archiver,
 
 	a.zw = zip.NewWriter(w)
 
-	// register standard flate compressor
-	a.RegisterCompressor(zip.Deflate, stdFlateCompressor(5))
+	// register flate compressor
+	a.RegisterCompressor(zip.Deflate, defaultCompressor)
 
 	return a, nil
 }

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -341,9 +341,9 @@ func benchmarkArchiveOptions(b *testing.B, stdDeflate bool, options ...ArchiverO
 
 		a, err := NewArchiver(f, *archiveDir, options...)
 		if stdDeflate {
-			a.RegisterCompressor(zip.Deflate, stdFlateCompressor(5))
+			a.RegisterCompressor(zip.Deflate, StdFlateCompressor(-1))
 		} else {
-			a.RegisterCompressor(zip.Deflate, FlateCompressor(5))
+			a.RegisterCompressor(zip.Deflate, FlateCompressor(-1))
 		}
 		require.NoError(b, err)
 

--- a/extractor.go
+++ b/extractor.go
@@ -24,6 +24,8 @@ var bufioWriterPool = sync.Pool{
 	},
 }
 
+var defaultDecompressor = FlateDecompressor()
+
 // Extractor is an opinionated Zip file extractor.
 //
 // Files are extracted in parallel. Only regular files, symlinks and directories
@@ -62,6 +64,8 @@ func NewExtractor(filename string, chroot string, opts ...ExtractorOption) (*Ext
 	if err != nil {
 		return nil, err
 	}
+
+	e.RegisterDecompressor(zip.Deflate, defaultDecompressor)
 
 	return e, nil
 }

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -100,7 +100,7 @@ func TestExtractorWithDecompressor(t *testing.T) {
 	testCreateArchive(t, dir, files, func(filename, chroot string) {
 		e, err := NewExtractor(filename, dir)
 		require.NoError(t, err)
-		e.RegisterDecompressor(zip.Deflate, FlateDecompressor())
+		e.RegisterDecompressor(zip.Deflate, StdFlateDecompressor())
 		defer e.Close()
 
 		require.NoError(t, e.Extract())
@@ -178,7 +178,7 @@ func benchmarkExtractOptions(b *testing.B, store bool, stdDeflate bool, options 
 		a, err = NewArchiver(f, *archiveDir, WithStageDirectory(dir), WithArchiverMethod(zip.Store))
 	} else {
 		a, err = NewArchiver(f, *archiveDir, WithStageDirectory(dir))
-		a.RegisterCompressor(zip.Deflate, FlateCompressor(5))
+		a.RegisterCompressor(zip.Deflate, FlateCompressor(-1))
 	}
 	require.NoError(b, err)
 
@@ -194,8 +194,8 @@ func benchmarkExtractOptions(b *testing.B, store bool, stdDeflate bool, options 
 	b.SetBytes(fi.Size())
 	for n := 0; n < b.N; n++ {
 		e, err := NewExtractor(archiveName, dir, options...)
-		if !stdDeflate {
-			e.RegisterDecompressor(zip.Deflate, FlateDecompressor())
+		if stdDeflate {
+			e.RegisterDecompressor(zip.Deflate, StdFlateDecompressor())
 		}
 		require.NoError(b, err)
 		require.NoError(b, e.Extract())


### PR DESCRIPTION
Introduces StdFlateCompressor() and StdFlateDecompressor() for users wishing to use the standard library's archive/flate.

Archiver and extractor now uses klauspost/compress/flate by default to give users the most performant option without having to configure it.