### PR TITLE
Remove *WithContext() and require context to always be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ err = filepath.Walk("~/fastzip-archiving", func(pathname string, info os.FileInf
 })
 
 // Archive
-if err = a.Archive(files); err != nil {
+if err = a.Archive(context.Background(), files); err != nil {
   panic(err)
 }
 ```
@@ -58,7 +58,7 @@ if err != nil {
 defer e.Close()
 
 // Extract archive files
-if err = e.Extract(); err != nil {
+if err = e.Extract(context.Background()); err != nil {
   panic(err)
 }
 ```

--- a/archiver.go
+++ b/archiver.go
@@ -94,13 +94,8 @@ func (a *Archiver) Written() (bytes, entries int64) {
 	return atomic.LoadInt64(&a.written), atomic.LoadInt64(&a.entries)
 }
 
-// Archive calls ArchiveWithContext with a background context.
-func (a *Archiver) Archive(files map[string]os.FileInfo) (err error) {
-	return a.ArchiveWithContext(context.Background(), files)
-}
-
-// ArchiveWithContext archives all files, symlinks and directories.
-func (a *Archiver) ArchiveWithContext(ctx context.Context, files map[string]os.FileInfo) (err error) {
+// Archive archives all files, symlinks and directories.
+func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (err error) {
 	names := make([]string, 0, len(files))
 	for name := range files {
 		names = append(names, name)

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -71,7 +71,7 @@ func testCreateArchive(t *testing.T, dir string, files map[string]os.FileInfo, f
 
 	a, err := NewArchiver(f, dir)
 	require.NoError(t, err)
-	require.NoError(t, a.Archive(files))
+	require.NoError(t, a.Archive(context.Background(), files))
 	require.NoError(t, a.Close())
 
 	_, entries := a.Written()
@@ -135,7 +135,7 @@ func TestArchiveCancelContext(t *testing.T) {
 	go func() {
 		defer func() { done <- struct{}{} }()
 
-		require.EqualError(t, a.ArchiveWithContext(ctx, files), "context canceled")
+		require.EqualError(t, a.Archive(ctx, files), "context canceled")
 	}()
 
 	defer func() {
@@ -173,7 +173,7 @@ func TestArchiveWithCompressor(t *testing.T) {
 	a, err := NewArchiver(f, dir)
 	a.RegisterCompressor(zip.Deflate, FlateCompressor(1))
 	require.NoError(t, err)
-	require.NoError(t, a.Archive(files))
+	require.NoError(t, a.Archive(context.Background(), files))
 	require.NoError(t, a.Close())
 
 	bytes, entries := a.Written()
@@ -199,7 +199,7 @@ func TestArchiveWithMethod(t *testing.T) {
 
 	a, err := NewArchiver(f, dir, WithArchiverMethod(zip.Store))
 	require.NoError(t, err)
-	require.NoError(t, a.Archive(files))
+	require.NoError(t, a.Archive(context.Background(), files))
 	require.NoError(t, a.Close())
 
 	bytes, entries := a.Written()
@@ -229,7 +229,7 @@ func TestArchiveWithStageDirectory(t *testing.T) {
 
 	a, err := NewArchiver(f, chroot, WithStageDirectory(dir))
 	require.NoError(t, err)
-	require.NoError(t, a.Archive(files))
+	require.NoError(t, a.Archive(context.Background(), files))
 	require.NoError(t, a.Close())
 
 	bytes, entries := a.Written()
@@ -276,7 +276,7 @@ func TestArchiveWithConcurrency(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.NoError(t, a.Archive(files))
+			require.NoError(t, a.Archive(context.Background(), files))
 			require.NoError(t, a.Close())
 
 			bytes, entries := a.Written()
@@ -326,7 +326,7 @@ func TestArchiveChroot(t *testing.T) {
 			files[w.Name()] = stat
 		}
 
-		err = a.Archive(files)
+		err = a.Archive(context.Background(), files)
 		if test.good {
 			assert.NoError(t, err)
 		} else {
@@ -353,7 +353,7 @@ func TestArchiveWithOffset(t *testing.T) {
 
 	a, err := NewArchiver(f, dir, WithArchiverOffset(1000))
 	require.NoError(t, err)
-	require.NoError(t, a.Archive(files))
+	require.NoError(t, a.Archive(context.Background(), files))
 	require.NoError(t, a.Close())
 
 	bytes, entries := a.Written()
@@ -395,7 +395,7 @@ func benchmarkArchiveOptions(b *testing.B, stdDeflate bool, options ...ArchiverO
 		}
 		require.NoError(b, err)
 
-		err = a.Archive(files)
+		err = a.Archive(context.Background(), files)
 		require.NoError(b, err)
 
 		require.NoError(b, a.Close())

--- a/extractor.go
+++ b/extractor.go
@@ -92,14 +92,9 @@ func (e *Extractor) Written() (bytes, entries int64) {
 	return atomic.LoadInt64(&e.written), atomic.LoadInt64(&e.entries)
 }
 
-// Extract calls ExtractWithContext with a background context.
-func (e *Extractor) Extract() error {
-	return e.ExtractWithContext(context.Background())
-}
-
-// ExtractWithContext extracts files, creates symlinks and directories from the
+// Extract extracts files, creates symlinks and directories from the
 // archive.
-func (e *Extractor) ExtractWithContext(ctx context.Context) (err error) {
+func (e *Extractor) Extract(ctx context.Context) (err error) {
 	limiter := make(chan struct{}, e.options.concurrency)
 
 	wg, ctx := errgroup.WithContext(ctx)

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -22,7 +22,7 @@ func testExtract(t *testing.T, filename string, files map[string]testFile) {
 	require.NoError(t, err)
 	defer e.Close()
 
-	require.NoError(t, e.Extract())
+	require.NoError(t, e.Extract(context.Background()))
 
 	err = filepath.Walk(dir, func(pathname string, fi os.FileInfo, err error) error {
 		if err != nil {
@@ -70,7 +70,7 @@ func TestExtractCancelContext(t *testing.T) {
 		go func() {
 			defer func() { done <- struct{}{} }()
 
-			require.EqualError(t, e.ExtractWithContext(ctx), "context canceled")
+			require.EqualError(t, e.Extract(ctx), "context canceled")
 		}()
 
 		for {
@@ -103,7 +103,7 @@ func TestExtractorWithDecompressor(t *testing.T) {
 		e.RegisterDecompressor(zip.Deflate, StdFlateDecompressor())
 		defer e.Close()
 
-		require.NoError(t, e.Extract())
+		require.NoError(t, e.Extract(context.Background()))
 	})
 }
 
@@ -182,7 +182,7 @@ func benchmarkExtractOptions(b *testing.B, store, stdDeflate bool, options ...Ex
 	}
 	require.NoError(b, err)
 
-	err = a.Archive(files)
+	err = a.Archive(context.Background(), files)
 	require.NoError(b, err)
 	require.NoError(b, a.Close())
 	require.NoError(b, f.Close())
@@ -198,7 +198,7 @@ func benchmarkExtractOptions(b *testing.B, store, stdDeflate bool, options ...Ex
 			e.RegisterDecompressor(zip.Deflate, StdFlateDecompressor())
 		}
 		require.NoError(b, err)
-		require.NoError(b, e.Extract())
+		require.NoError(b, e.Extract(context.Background()))
 	}
 }
 


### PR DESCRIPTION
This removes `ExtractWithContext` and `ArchiveWithContext` in favour of having a smaller public API.

This is done in preparation for a v1.0.0 release.