### PR TITLE
Fix chown error handler

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -298,7 +298,7 @@ func (e *Extractor) updateFileMetadata(path string, file *zip.File) error {
 	}
 
 	err = lchown(path, int(unix.Uid.Int64()), int(unix.Gid.Int64()))
-	if err != nil {
+	if err == nil {
 		return nil
 	}
 

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -150,9 +150,11 @@ func TestExtractorWithChownErrorHandler(t *testing.T) {
 
 	testCreateArchive(t, dir, files, func(filename, chroot string) {
 		e, err := NewExtractor(filename, dir, WithExtractorChownErrorHandler(func(name string, err error) error {
+			assert.Fail(t, "should have no error")
 			return nil
 		}))
 		assert.NoError(t, err)
+		assert.NoError(t, e.Extract(context.Background()))
 		require.NoError(t, e.Close())
 	})
 }


### PR DESCRIPTION
A bug was introduced in https://github.com/saracen/fastzip/pull/11 where the chown error handler was not being called for errors correctly.