### PR TITLE
Add initial buffer to filepool

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -109,7 +109,7 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 		concurrency = len(files)
 	}
 	if concurrency > 1 {
-		fp, err = filepool.New(a.options.stageDir, concurrency)
+		fp, err = filepool.New(a.options.stageDir, concurrency, a.options.bufferSize)
 		if err != nil {
 			return err
 		}

--- a/archiver_options.go
+++ b/archiver_options.go
@@ -12,6 +12,7 @@ type ArchiverOption func(*archiverOptions) error
 type archiverOptions struct {
 	method      uint16
 	concurrency int
+	bufferSize  int
 	stageDir    string
 	offset      int64
 }
@@ -25,13 +26,28 @@ func WithArchiverMethod(method uint16) ArchiverOption {
 }
 
 // WithArchiverConcurrency will set the maximum number of files to be
-// compressed concurrently. The default is GOMAXPROCS.
+// compressed concurrently. The default is set to runtime.NumCPU().
 func WithArchiverConcurrency(n int) ArchiverOption {
 	return func(o *archiverOptions) error {
 		if n <= 0 {
 			return ErrMinConcurrency
 		}
 		o.concurrency = n
+		return nil
+	}
+}
+
+// WithArchiverBufferSize sets the buffer size for each file to be compressed
+// concurrently. If a compressed file's data exceeds the buffer size, a
+// temporary file is written (to the stage directory) to hold the additional
+// data. The default is 2 mebibytes, so if concurrency is 16, 32 mebibytes of
+// memory will be allocated.
+//
+// If set to -1, no buffer will be used and all compressed file content will be
+// written to temporary files before being written back to the zip file.
+func WithArchiverBufferSize(n int) ArchiverOption {
+	return func(o *archiverOptions) error {
+		o.bufferSize = n
 		return nil
 	}
 }


### PR DESCRIPTION
This PR adds support for an initial buffer, before writing to a temporary filepool file. This is intended to improve concurrency archiving performance.

On Linux (ext4) there's a minor improvement. Here the buffer size is set to 2MB, and there's not a file above that in the directory being archived.

The reason for not adding this in the past was because I figured Linux would do a fine job of caching the reads/writes on my behalf. This is mostly true it seems.

Before:
```
BenchmarkArchiveNonStandardFlate_1-24     	       4	5978756966 ns/op	  55.62 MB/s	11336886 B/op	  243855 allocs/op
BenchmarkArchiveNonStandardFlate_2-24     	       7	3453616610 ns/op	  96.28 MB/s	21684099 B/op	  260948 allocs/op
BenchmarkArchiveNonStandardFlate_4-24     	      12	1802280097 ns/op	 184.50 MB/s	25144844 B/op	  258473 allocs/op
BenchmarkArchiveNonStandardFlate_8-24     	      22	 992630918 ns/op	 334.99 MB/s	39847705 B/op	  259066 allocs/op
BenchmarkArchiveNonStandardFlate_16-24    	      31	 761136774 ns/op	 436.87 MB/s	47155177 B/op	  257977 allocs/op
```

After:
```
BenchmarkArchiveNonStandardFlate_1-24     	       4	5857513095 ns/op	  56.77 MB/s	11328352 B/op	  243856 allocs/op
BenchmarkArchiveNonStandardFlate_2-24     	       7	3157835078 ns/op	 105.30 MB/s	24326099 B/op	  261076 allocs/op
BenchmarkArchiveNonStandardFlate_4-24     	      13	1684061558 ns/op	 197.45 MB/s	35855322 B/op	  259711 allocs/op
BenchmarkArchiveNonStandardFlate_8-24     	      25	 926217080 ns/op	 359.01 MB/s	57637974 B/op	  259297 allocs/op
BenchmarkArchiveNonStandardFlate_16-24    	      30	 744493736 ns/op	 446.64 MB/s	82054441 B/op	  259390 allocs/op
```

Testing on MacOS though, there's a much larger improvement:

Before:
```
BenchmarkArchiveNonStandardFlate_1-16     	       6	3673151117 ns/op	  89.25 MB/s	11588274 B/op	  243860 allocs/op
BenchmarkArchiveNonStandardFlate_2-16     	       9	2600023564 ns/op	 126.08 MB/s	18363304 B/op	  259793 allocs/op
BenchmarkArchiveNonStandardFlate_4-16     	      15	1420703570 ns/op	 230.75 MB/s	23616730 B/op	  258694 allocs/op
BenchmarkArchiveNonStandardFlate_8-16     	      24	1052624485 ns/op	 311.43 MB/s	34149704 B/op	  259846 allocs/op
BenchmarkArchiveNonStandardFlate_16-16    	      25	1062548537 ns/op	 308.52 MB/s	41979502 B/op	  258196 allocs/op
```

After:
```
BenchmarkArchiveNonStandardFlate_1-16     	       6	3718459083 ns/op	  88.16 MB/s	11594606 B/op	  243863 allocs/op
BenchmarkArchiveNonStandardFlate_2-16     	      10	2135667449 ns/op	 153.50 MB/s	21661184 B/op	  260385 allocs/op
BenchmarkArchiveNonStandardFlate_4-16     	      19	1174026691 ns/op	 279.23 MB/s	33046460 B/op	  260989 allocs/op
BenchmarkArchiveNonStandardFlate_8-16     	      32	 822081039 ns/op	 398.77 MB/s	53274860 B/op	  259359 allocs/op
BenchmarkArchiveNonStandardFlate_16-16    	      33	 767014905 ns/op	 427.40 MB/s	72300987 B/op	  259924 allocs/op
```