### PR TITLE
Dependency update: flate performance and extrazip bug fix

### DIFF
--- a/archiver_test.go
+++ b/archiver_test.go
@@ -3,6 +3,7 @@ package fastzip
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -123,9 +124,9 @@ func TestArchive(t *testing.T) {
 
 func TestArchiveCancelContext(t *testing.T) {
 	twoMB := strings.Repeat("1", 2*1024*1024)
-	testFiles := map[string]testFile{
-		"foo.go": {mode: 0666, contents: twoMB},
-		"bar.go": {mode: 0666, contents: twoMB},
+	testFiles := map[string]testFile{}
+	for i := 0; i < 100; i++ {
+		testFiles[fmt.Sprintf("file_%d", i)] = testFile{mode: 0666, contents: twoMB}
 	}
 
 	files, dir := testCreateFiles(t, testFiles)

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -2,6 +2,7 @@ package fastzip
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -59,11 +60,9 @@ func testExtract(t *testing.T, filename string, files map[string]testFile) {
 
 func TestExtractCancelContext(t *testing.T) {
 	twoMB := strings.Repeat("1", 2*1024*1024)
-	testFiles := map[string]testFile{
-		"foo.go":    {mode: 0666, contents: twoMB},
-		"bar.go":    {mode: 0666, contents: twoMB},
-		"foobar.go": {mode: 0666, contents: twoMB},
-		"barfoo.go": {mode: 0666, contents: twoMB},
+	testFiles := map[string]testFile{}
+	for i := 0; i < 100; i++ {
+		testFiles[fmt.Sprintf("file_%d", i)] = testFile{mode: 0666, contents: twoMB}
 	}
 
 	files, dir := testCreateFiles(t, testFiles)

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/saracen/fastzip
 go 1.13
 
 require (
-	github.com/klauspost/compress v1.11.2
-	github.com/saracen/zipextra v0.0.0-20191018034721-f8fcc2e1b58e
+	github.com/klauspost/compress v1.11.3
+	github.com/saracen/zipextra v0.0.0-20201205103923-7347a2ee3f10
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520
 	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,14 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/klauspost/compress v1.11.2 h1:MiK62aErc3gIiVEtyzKfeOHgW7atJb5g/KNX5m3c2nQ=
 github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.3 h1:dB4Bn0tN3wdCzQxnS8r06kV74qN/TAfaIS0bVE8h3jc=
+github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/saracen/zipextra v0.0.0-20191018034721-f8fcc2e1b58e h1:psyRxwoYbvGxzM8WucxDD5TJ994ePVteYpeb4BIZVic=
 github.com/saracen/zipextra v0.0.0-20191018034721-f8fcc2e1b58e/go.mod h1:6Zk1rDeZXl7t6qPppqntIzWu6A+k9OYmT1LzehKE6e0=
+github.com/saracen/zipextra v0.0.0-20201205103923-7347a2ee3f10 h1:UdM0Zmjq5MlMEnSu1M+dbJI6/YwlNLiO6p+IJJ3au4A=
+github.com/saracen/zipextra v0.0.0-20201205103923-7347a2ee3f10/go.mod h1:6Zk1rDeZXl7t6qPppqntIzWu6A+k9OYmT1LzehKE6e0=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=


### PR DESCRIPTION
Updates klauspost/compress to v1.11.3 (inflate 10-15% faster).

Updates extrazip for improved compatibility with other archivers.