### PR TITLE
Updates klauspost/compress to v1.14.3

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -243,7 +243,7 @@ func (a *Archiver) createFile(ctx context.Context, path string, fi os.FileInfo, 
 }
 
 // compressFile pre-compresses the file first to a file from the filepool,
-// making use of zip.CreateHeaderRaw. This allows for concurrent files to be
+// making use of zip.CreateRaw. This allows for concurrent files to be
 // compressed and then added to the zip file when ready.
 // If no filepool file is available (when using a concurrency of 1) or the
 // compressed file is larger than the uncompressed version, the file is moved
@@ -283,7 +283,7 @@ func (a *Archiver) compressFile(ctx context.Context, f *os.File, fi os.FileInfo,
 	a.m.Lock()
 	defer a.m.Unlock()
 
-	w, err := a.createHeaderRaw(fi, hdr)
+	w, err := a.createRaw(fi, hdr)
 	if err != nil {
 		return err
 	}

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -101,6 +101,7 @@ func TestArchive(t *testing.T) {
 		"bar/compressible":    {mode: 0666, contents: "11111111111111111111111111111111111111111111111111"},
 		"bar/uncompressible":  {mode: 0666, contents: "A3#bez&OqCusPr)d&D]Vot9Eo0z^5O*VZm3:sO3HptL.H-4cOv"},
 		"empty_dir":           {mode: os.ModeDir | 0777},
+		"large_file":          {mode: 0666, contents: strings.Repeat("abcdefzmkdldjsdfkjsdfsdfiqwpsdfa", 65536)},
 	}
 
 	tests := map[string][]ArchiverOption{

--- a/archiver_unix.go
+++ b/archiver_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package fastzip
@@ -21,11 +22,11 @@ func (a *Archiver) createHeader(fi os.FileInfo, hdr *zip.FileHeader) (io.Writer,
 	return a.zw.CreateHeader(hdr)
 }
 
-func (a *Archiver) createHeaderRaw(fi os.FileInfo, hdr *zip.FileHeader) (io.Writer, error) {
+func (a *Archiver) createRaw(fi os.FileInfo, hdr *zip.FileHeader) (io.Writer, error) {
 	stat, ok := fi.Sys().(*syscall.Stat_t)
 	if ok {
 		hdr.Extra = append(hdr.Extra, zipextra.NewInfoZIPNewUnix(big.NewInt(int64(stat.Uid)), big.NewInt(int64(stat.Gid))).Encode()...)
 	}
 
-	return a.zw.CreateHeaderRaw(hdr)
+	return a.zw.CreateRaw(hdr)
 }

--- a/archiver_windows.go
+++ b/archiver_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fastzip
@@ -13,6 +14,6 @@ func (a *Archiver) createHeader(fi os.FileInfo, hdr *zip.FileHeader) (io.Writer,
 	return a.zw.CreateHeader(hdr)
 }
 
-func (a *Archiver) createHeaderRaw(fi os.FileInfo, hdr *zip.FileHeader) (io.Writer, error) {
-	return a.zw.CreateHeaderRaw(hdr)
+func (a *Archiver) createRaw(fi os.FileInfo, hdr *zip.FileHeader) (io.Writer, error) {
+	return a.zw.CreateRaw(hdr)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/saracen/fastzip
 
-go 1.13
+go 1.15
 
 require (
-	github.com/klauspost/compress v1.13.5
+	github.com/klauspost/compress v1.14.3
 	github.com/saracen/zipextra v0.0.0-20201205103923-7347a2ee3f10
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/klauspost/compress v1.13.5 h1:9O69jUPDcsT9fEm74W92rZL9FQY7rCdaXVneq+yyzl4=
-github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.14.3 h1:DQv1WP+iS4srNjibdnHtqu8JNWCDMluj5NzPnFJsnvk=
+github.com/klauspost/compress v1.14.3/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/saracen/zipextra v0.0.0-20201205103923-7347a2ee3f10 h1:UdM0Zmjq5MlMEnSu1M+dbJI6/YwlNLiO6p+IJJ3au4A=


### PR DESCRIPTION
This also now calls the newer CreateRaw() method, as CreateHeaderRaw() is now deprecated.

This fixes #32, as when CreateHeaderRaw() was deprecated, it started calling the incorrect function that replaced it: https://github.com/klauspost/compress/pull/502

A test with a larger content body has been added as it was able to detect this regression.

Fixes #32