### PR TITLE
Fix CreateRaw() flags and timestamps

### DIFF
--- a/extractor_test.go
+++ b/extractor_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testExtract(t *testing.T, filename string, files map[string]testFile) {
+func testExtract(t *testing.T, filename string, files map[string]testFile) map[string]os.FileInfo {
 	dir, err := ioutil.TempDir("", "fastzip-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -29,6 +29,7 @@ func testExtract(t *testing.T, filename string, files map[string]testFile) {
 
 	require.NoError(t, e.Extract(context.Background()))
 
+	result := make(map[string]os.FileInfo)
 	err = filepath.Walk(dir, func(pathname string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -43,6 +44,8 @@ func testExtract(t *testing.T, filename string, files map[string]testFile) {
 
 		rel = filepath.ToSlash(rel)
 		require.Contains(t, files, rel)
+
+		result[pathname] = fi
 
 		mode := files[rel].mode
 		assert.Equal(t, mode.Perm(), fi.Mode().Perm(), "file %v perm not equal", rel)
@@ -60,6 +63,8 @@ func testExtract(t *testing.T, filename string, files map[string]testFile) {
 		return nil
 	})
 	require.NoError(t, err)
+
+	return result
 }
 
 func TestExtractCancelContext(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/saracen/fastzip
 go 1.15
 
 require (
-	github.com/klauspost/compress v1.14.3
-	github.com/saracen/zipextra v0.0.0-20201205103923-7347a2ee3f10
+	github.com/klauspost/compress v1.14.4
+	github.com/saracen/zipextra v0.0.0-20220303013732-0187cb0159ea
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/klauspost/compress v1.14.3 h1:DQv1WP+iS4srNjibdnHtqu8JNWCDMluj5NzPnFJsnvk=
-github.com/klauspost/compress v1.14.3/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=
+github.com/klauspost/compress v1.14.4/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/saracen/zipextra v0.0.0-20201205103923-7347a2ee3f10 h1:UdM0Zmjq5MlMEnSu1M+dbJI6/YwlNLiO6p+IJJ3au4A=
-github.com/saracen/zipextra v0.0.0-20201205103923-7347a2ee3f10/go.mod h1:6Zk1rDeZXl7t6qPppqntIzWu6A+k9OYmT1LzehKE6e0=
+github.com/saracen/zipextra v0.0.0-20220303013732-0187cb0159ea h1:8czYLkvzZRE+AElIQeDffQdgR+CC3wKEFILYU/1PeX4=
+github.com/saracen/zipextra v0.0.0-20220303013732-0187cb0159ea/go.mod h1:hnzuad9d2wdd3z8fC6UouHQK5qZxqv3F/E6MMzXc7q0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
When the standard Go library's version of `CreateRaw` was added, rather than solely focus on custom compression in "raw" mode, it also removed the convenience of setting up common zip flags and timestamp logic.

This change duplicates some functions from `archive/zip` to add the flags and timestamp logic to `CreateRaw()`.

This fixes an issue raised by a user of GitLab-Runner https://gitlab.com/gitlab-org/gitlab-runner/-/issues/28928 where timestamps were missing whenever `CreateRaw` was used.