### PR TITLE
Rate-limit active go routines

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -173,8 +173,8 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 				err = a.createFile(ctx, path, fi, hdr, nil)
 				incOnSuccess(&a.entries, err)
 			} else {
+				f := fp.Get()
 				wg.Go(func() error {
-					f := fp.Get()
 					err := a.createFile(ctx, path, fi, hdr, f)
 					fp.Put(f)
 					incOnSuccess(&a.entries, err)


### PR DESCRIPTION
The `filepool`'s `Get()`/`Put()` was designed to rate limit up to a certain concurrency, and whilst the unit of work is rate limited, we launch as many go routines as there are files to be archived first. By moving the `Get()` call outside of a go routine, we also limit the amount of go routines created at once.

This likely has memory savings, but also allows the `-race` detector to work when archiving many thousands of files.