### PR TITLE
A buffer size of zero uses no buffer, rather than default size

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -65,6 +65,7 @@ func NewArchiver(w io.Writer, chroot string, opts ...ArchiverOption) (*Archiver,
 	a.options.method = zip.Deflate
 	a.options.concurrency = runtime.NumCPU()
 	a.options.stageDir = chroot
+	a.options.bufferSize = -1
 	for _, o := range opts {
 		err := o(&a.options)
 		if err != nil {

--- a/archiver_options.go
+++ b/archiver_options.go
@@ -6,7 +6,6 @@ import (
 
 var (
 	ErrMinConcurrency = errors.New("concurrency must be at least 1")
-	ErrMinBufferSize  = errors.New("buffer size option cannot be less than -1")
 )
 
 // ArchiverOption is an option used when creating an archiver.
@@ -45,13 +44,10 @@ func WithArchiverConcurrency(n int) ArchiverOption {
 // temporary file is written (to the stage directory) to hold the additional
 // data. The default is 2 mebibytes, so if concurrency is 16, 32 mebibytes of
 // memory will be allocated.
-//
-// If set to -1, no buffer will be used and all compressed file content will be
-// written to temporary files before being written back to the zip file.
 func WithArchiverBufferSize(n int) ArchiverOption {
 	return func(o *archiverOptions) error {
-		if n < -1 {
-			return ErrMinBufferSize
+		if n < 0 {
+			n = 0
 		}
 		o.bufferSize = n
 		return nil

--- a/internal/filepool/filepool.go
+++ b/internal/filepool/filepool.go
@@ -57,10 +57,7 @@ func New(dir string, poolSize int, bufferSize int) (*FilePool, error) {
 	fp.files = make([]*File, poolSize)
 	fp.limiter = make(chan int, poolSize)
 
-	switch bufferSize {
-	case -1:
-		bufferSize = 0
-	case 0:
+	if bufferSize < 0 {
 		bufferSize = defaultBufferSize
 	}
 

--- a/internal/filepool/filepool_test.go
+++ b/internal/filepool/filepool_test.go
@@ -31,7 +31,7 @@ func TestFilePoolSizes(t *testing.T) {
 			require.NoError(t, err)
 			defer os.RemoveAll(dir)
 
-			fp, err := New(dir, tc.size, -1)
+			fp, err := New(dir, tc.size, 0)
 			require.Equal(t, tc.err, err)
 			if tc.err != nil {
 				return
@@ -63,7 +63,7 @@ func TestFilePoolReset(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	fp, err := New(dir, 16, -1)
+	fp, err := New(dir, 16, 0)
 	require.NoError(t, err)
 	for i := range fp.files {
 		file := fp.Get()
@@ -102,7 +102,7 @@ func TestFilePoolCloseError(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	fp, err := New(dir, 16, -1)
+	fp, err := New(dir, 16, 0)
 	require.NoError(t, err)
 
 	for _, file := range fp.files {
@@ -135,7 +135,7 @@ func TestFilePoolNoErrorOnAlreadyDeleted(t *testing.T) {
 	dir, err := ioutil.TempDir("", "fastzip-filepool")
 	require.NoError(t, err)
 
-	fp, err := New(dir, 16, -1)
+	fp, err := New(dir, 16, 0)
 	require.NoError(t, err)
 
 	for range fp.files {


### PR DESCRIPTION
Previously, a buffer size of zero would use the default buffer size and -1 would disable the buffer. This is probably confusing/unexpected.

This change remains backwards compatible, as <= 0 will disable the buffer.