### PR TITLE
Update readme to add a missing error check in the archiving example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ defer a.Close()
 
 // Walk directory, adding the files we want to add
 files := make(map[string]os.FileInfo)
-err = filepath.Walk("~/fastzip-archiving", func(pathname string, info os.FileInfo, err error) error {
+if err = filepath.Walk("~/fastzip-archiving", func(pathname string, info os.FileInfo, err error) error {
 	files[pathname] = info
 	return nil
-})
+}); err != nil {
+  panic(err)
+}
 
 // Archive
 if err = a.Archive(context.Background(), files); err != nil {


### PR DESCRIPTION
I noticed this error check was missing when I was shamelessly copy/pasting the example into my project.