### PR TITLE
Add WithStableFileOrder for deterministic archives

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # earliest supported go version and latest 2 versions we support
-        go: [1.22.x, 1.24.x, 1.25.x]
+        go: [1.23.x, 1.24.x, 1.25.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        # earliest supported go version and latest 2 versions we support
-        go: [1.23.x, 1.24.x, 1.25.x]
+        # earliest supported go version and the recent versions we support
+        go: [1.23.x, 1.24.x, 1.25.x, 1.26.x, 1.27.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/archiver.go
+++ b/archiver.go
@@ -52,6 +52,11 @@ type Archiver struct {
 	chroot  string
 	m       sync.Mutex
 
+	// order serializes entry writes so the archive is deterministic. It is
+	// non-nil only when the stable file order option is enabled and is created
+	// per Archive call.
+	order *writeSerializer
+
 	compressors map[uint16]zip.Compressor
 }
 
@@ -135,9 +140,21 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 		}
 	}()
 
+	if a.options.stableFileOrder {
+		a.order = newWriteSerializer()
+		// Registered after the wg.Wait deferral above so it runs first (defers
+		// are LIFO): any goroutine blocked on its write turn is released before
+		// we wait on it, avoiding a hang when we return before dispatching every
+		// entry.
+		defer a.order.abort()
+	}
+
 	hdrs := make([]zip.FileHeader, len(names))
 
-	for i, name := range names {
+	// idx numbers the entries that are actually archived, contiguously from 0,
+	// so the write serializer never stalls on a skipped index.
+	idx := 0
+	for _, name := range names {
 		fi := files[name]
 		if fi.Mode()&irregularModes != 0 {
 			continue
@@ -157,7 +174,10 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 			return err
 		}
 
-		hdr := &hdrs[i]
+		entryIdx := idx
+		idx++
+
+		hdr := &hdrs[entryIdx]
 		fileInfoHeader(rel, fi, hdr)
 
 		if ctx.Err() != nil {
@@ -166,10 +186,10 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 
 		switch {
 		case hdr.Mode()&os.ModeSymlink != 0:
-			err = a.createSymlink(path, fi, hdr)
+			err = a.createSymlink(entryIdx, path, fi, hdr)
 
 		case hdr.Mode().IsDir():
-			err = a.createDirectory(fi, hdr)
+			err = a.createDirectory(entryIdx, fi, hdr)
 
 		default:
 			if hdr.UncompressedSize64 > 0 {
@@ -177,12 +197,12 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 			}
 
 			if fp == nil {
-				err = a.createFile(ctx, path, fi, hdr, nil)
+				err = a.createFile(ctx, entryIdx, path, fi, hdr, nil)
 				incOnSuccess(&a.entries, err)
 			} else {
 				f := fp.Get()
 				wg.Go(func() error {
-					err := a.createFile(ctx, path, fi, hdr, f)
+					err := a.createFile(ctx, entryIdx, path, fi, hdr, f)
 					fp.Put(f)
 					incOnSuccess(&a.entries, err)
 					return err
@@ -196,6 +216,20 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 	}
 
 	return wg.Wait()
+}
+
+// writeEntry serializes a single entry's write to the zip. When stable file
+// ordering is enabled the write also waits for its turn, so entries are written
+// in enumeration order regardless of when their compression finished. In both
+// cases fn runs with exclusive access to the underlying zip.Writer.
+func (a *Archiver) writeEntry(idx int, fn func() error) error {
+	if a.order != nil {
+		return a.order.do(idx, fn)
+	}
+
+	a.m.Lock()
+	defer a.m.Unlock()
+	return fn()
 }
 
 func fileInfoHeader(name string, fi os.FileInfo, hdr *zip.FileHeader) {
@@ -216,19 +250,15 @@ func fileInfoHeader(name string, fi os.FileInfo, hdr *zip.FileHeader) {
 	}
 }
 
-func (a *Archiver) createDirectory(fi os.FileInfo, hdr *zip.FileHeader) error {
-	a.m.Lock()
-	defer a.m.Unlock()
-
-	_, err := a.createHeader(fi, hdr)
-	incOnSuccess(&a.entries, err)
-	return err
+func (a *Archiver) createDirectory(idx int, fi os.FileInfo, hdr *zip.FileHeader) error {
+	return a.writeEntry(idx, func() error {
+		_, err := a.createHeader(fi, hdr)
+		incOnSuccess(&a.entries, err)
+		return err
+	})
 }
 
-func (a *Archiver) createSymlink(path string, fi os.FileInfo, hdr *zip.FileHeader) error {
-	a.m.Lock()
-	defer a.m.Unlock()
-
+func (a *Archiver) createSymlink(idx int, path string, fi os.FileInfo, hdr *zip.FileHeader) error {
 	link, err := os.Readlink(path)
 	if err != nil {
 		return err
@@ -241,24 +271,26 @@ func (a *Archiver) createSymlink(path string, fi os.FileInfo, hdr *zip.FileHeade
 	hdr.UncompressedSize64 = hdr.CompressedSize64
 	hdr.CRC32 = crc32.ChecksumIEEE([]byte(link))
 
-	w, err := a.createHeaderRaw(fi, hdr)
-	if err != nil {
-		return err
-	}
+	return a.writeEntry(idx, func() error {
+		w, err := a.createHeaderRaw(fi, hdr)
+		if err != nil {
+			return err
+		}
 
-	_, err = io.WriteString(w, link)
-	incOnSuccess(&a.entries, err)
-	return err
+		_, err = io.WriteString(w, link)
+		incOnSuccess(&a.entries, err)
+		return err
+	})
 }
 
-func (a *Archiver) createFile(ctx context.Context, path string, fi os.FileInfo, hdr *zip.FileHeader, tmp *filepool.File) error {
+func (a *Archiver) createFile(ctx context.Context, idx int, path string, fi os.FileInfo, hdr *zip.FileHeader, tmp *filepool.File) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	return a.compressFile(ctx, f, fi, hdr, tmp)
+	return a.compressFile(ctx, idx, f, fi, hdr, tmp)
 }
 
 // compressFile pre-compresses the file first to a file from the filepool,
@@ -267,12 +299,12 @@ func (a *Archiver) createFile(ctx context.Context, path string, fi os.FileInfo, 
 // If no filepool file is available (when using a concurrency of 1) or the
 // compressed file is larger than the uncompressed version, the file is moved
 // to the zip file using the conventional zip.CreateHeader.
-func (a *Archiver) compressFile(ctx context.Context, f *os.File, fi os.FileInfo, hdr *zip.FileHeader, tmp *filepool.File) error {
+func (a *Archiver) compressFile(ctx context.Context, idx int, f *os.File, fi os.FileInfo, hdr *zip.FileHeader, tmp *filepool.File) error {
 	comp, ok := a.compressors[hdr.Method]
 	// if we don't have the registered compressor, it most likely means Store is
 	// being used, so we revert to non-concurrent behaviour
 	if !ok || tmp == nil {
-		return a.compressFileSimple(ctx, f, fi, hdr)
+		return a.compressFileSimple(ctx, idx, f, fi, hdr)
 	}
 
 	fw, err := comp(tmp)
@@ -296,41 +328,39 @@ func (a *Archiver) compressFile(ctx context.Context, f *os.File, fi os.FileInfo,
 	if hdr.CompressedSize64 > hdr.UncompressedSize64 {
 		f.Seek(0, io.SeekStart)
 		hdr.Method = zip.Store
-		return a.compressFileSimple(ctx, f, fi, hdr)
+		return a.compressFileSimple(ctx, idx, f, fi, hdr)
 	}
 	hdr.CRC32 = tmp.Checksum()
 
-	a.m.Lock()
-	defer a.m.Unlock()
+	return a.writeEntry(idx, func() error {
+		w, err := a.createHeaderRaw(fi, hdr)
+		if err != nil {
+			return err
+		}
 
-	w, err := a.createHeaderRaw(fi, hdr)
-	if err != nil {
+		br.Reset(tmp)
+		_, err = br.WriteTo(countWriter{w, &a.written, ctx})
 		return err
-	}
-
-	br.Reset(tmp)
-	_, err = br.WriteTo(countWriter{w, &a.written, ctx})
-	return err
+	})
 }
 
 // compressFileSimple uses the conventional zip.createHeader. This differs from
 // compressFile as it locks the zip _whilst_ compressing (if the method is not
 // Store).
-func (a *Archiver) compressFileSimple(ctx context.Context, f *os.File, fi os.FileInfo, hdr *zip.FileHeader) error {
+func (a *Archiver) compressFileSimple(ctx context.Context, idx int, f *os.File, fi os.FileInfo, hdr *zip.FileHeader) error {
 	br := bufioReaderPool.Get().(*bufio.Reader)
 	defer bufioReaderPool.Put(br)
 	br.Reset(f)
 
-	a.m.Lock()
-	defer a.m.Unlock()
+	return a.writeEntry(idx, func() error {
+		w, err := a.createHeader(fi, hdr)
+		if err != nil {
+			return err
+		}
 
-	w, err := a.createHeader(fi, hdr)
-	if err != nil {
+		_, err = br.WriteTo(countWriter{w, &a.written, ctx})
 		return err
-	}
-
-	_, err = br.WriteTo(countWriter{w, &a.written, ctx})
-	return err
+	})
 }
 
 func (a *Archiver) createHeaderRaw(fi os.FileInfo, fh *zip.FileHeader) (io.Writer, error) {

--- a/archiver.go
+++ b/archiver.go
@@ -2,6 +2,7 @@ package fastzip
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"hash/crc32"
@@ -144,7 +145,14 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 	// concurrency of 1 the dispatch loop already writes them in order.
 	a.order = nil
 	if a.options.stableFileOrder && fp != nil {
-		a.order = newWriteSerializer()
+		// Entries that finish before their turn may be copied out of their
+		// filepool slot and held in memory until written, up to this budget.
+		// Tie it to the filepool's own footprint so memory scales the same way.
+		bufferSize := a.options.bufferSize
+		if bufferSize < 0 {
+			bufferSize = filepool.DefaultBufferSize
+		}
+		a.order = newWriteSerializer(int64(concurrency) * int64(bufferSize))
 		// Registered after the wg.Wait deferral above so it runs first (defers
 		// are LIFO): any goroutine blocked on its write turn is released before
 		// we wait on it, avoiding a hang when we return before dispatching every
@@ -358,15 +366,9 @@ func (a *Archiver) compressFile(ctx context.Context, idx int, f *os.File, fi os.
 	}
 	hdr.CRC32 = tmp.Checksum()
 
-	return a.writeEntry(idx, func() error {
-		w, err := a.createHeaderRaw(fi, hdr)
-		if err != nil {
-			return err
-		}
-
-		br.Reset(tmp)
-		_, err = br.WriteTo(countWriter{w, &a.written, ctx})
-		return err
+	br.Reset(tmp)
+	return a.writeFileEntry(ctx, idx, int64(hdr.CompressedSize64), br, func() (io.Writer, error) {
+		return a.createHeaderRaw(fi, hdr)
 	})
 }
 
@@ -378,15 +380,63 @@ func (a *Archiver) compressFileSimple(ctx context.Context, idx int, f *os.File, 
 	defer bufioReaderPool.Put(br)
 	br.Reset(f)
 
-	return a.writeEntry(idx, func() error {
-		w, err := a.createHeader(fi, hdr)
+	return a.writeFileEntry(ctx, idx, int64(hdr.UncompressedSize64), br, func() (io.Writer, error) {
+		return a.createHeader(fi, hdr)
+	})
+}
+
+// writeFileEntry writes a file entry whose data is available from src, which
+// is expected to hold n bytes. create opens the entry in the zip once the write
+// has exclusive access to it.
+//
+// Without stable ordering, or when it is already this entry's turn, the data is
+// streamed from src. Otherwise the caller would have to wait for earlier
+// entries while holding its filepool slot, which starves the pool when many
+// small files sit behind a slow one. So if n fits the serializer's memory
+// budget, the data is copied out of src and the write queued, letting the
+// caller return its slot right away. Over budget, it waits with the slot.
+func (a *Archiver) writeFileEntry(ctx context.Context, idx int, n int64, src io.Reader, create func() (io.Writer, error)) error {
+	write := func(r io.Reader) error {
+		w, err := create()
 		if err != nil {
 			return err
 		}
 
-		_, err = br.WriteTo(countWriter{w, &a.written, ctx})
+		_, err = io.Copy(countWriter{w, &a.written, ctx}, r)
 		return err
-	})
+	}
+
+	if a.order == nil {
+		return a.writeEntry(idx, func() error { return write(src) })
+	}
+
+	if ran, err := a.order.tryDo(idx, func() error { return write(src) }); ran {
+		return err
+	}
+
+	if !a.order.reserve(n) {
+		return a.order.do(idx, func() error { return write(src) })
+	}
+
+	// Read one byte past n so a source that grew since it was stat'd is
+	// noticed rather than silently truncated.
+	buf := make([]byte, n+1)
+	m, err := io.ReadFull(src, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		a.order.release(n)
+		return err
+	}
+	if m <= int(n) {
+		return a.order.enqueueBytes(idx, n, func() error {
+			return write(bytes.NewReader(buf[:m]))
+		})
+	}
+
+	// Larger than expected: write everything, including what was already
+	// read, from the source once it is our turn.
+	a.order.release(n)
+	src = io.MultiReader(bytes.NewReader(buf), src)
+	return a.order.do(idx, func() error { return write(src) })
 }
 
 func (a *Archiver) createHeaderRaw(fi os.FileInfo, fh *zip.FileHeader) (io.Writer, error) {

--- a/archiver.go
+++ b/archiver.go
@@ -140,7 +140,10 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 		}
 	}()
 
-	if a.options.stableFileOrder {
+	// Ordering only matters when entries are written concurrently; at a
+	// concurrency of 1 the dispatch loop already writes them in order.
+	a.order = nil
+	if a.options.stableFileOrder && fp != nil {
 		a.order = newWriteSerializer()
 		// Registered after the wg.Wait deferral above so it runs first (defers
 		// are LIFO): any goroutine blocked on its write turn is released before
@@ -239,6 +242,22 @@ func (a *Archiver) writeEntry(idx int, fn func() error) error {
 	return fn()
 }
 
+// writeEntryNoWait is writeEntry for entries that are written from the
+// dispatch loop and hold no filepool file (directories and symlinks). With
+// stable file ordering the write is queued rather than waited for, so the loop
+// keeps dispatching files instead of draining every in-flight compression each
+// time it meets a directory. The queued write runs, in order, from whichever
+// goroutine completes the entry before it; its error surfaces there.
+func (a *Archiver) writeEntryNoWait(idx int, fn func() error) error {
+	if a.order != nil {
+		return a.order.enqueue(idx, fn)
+	}
+
+	a.m.Lock()
+	defer a.m.Unlock()
+	return fn()
+}
+
 func fileInfoHeader(name string, fi os.FileInfo, hdr *zip.FileHeader) {
 	hdr.Name = filepath.ToSlash(name)
 	hdr.UncompressedSize64 = uint64(fi.Size())
@@ -258,7 +277,7 @@ func fileInfoHeader(name string, fi os.FileInfo, hdr *zip.FileHeader) {
 }
 
 func (a *Archiver) createDirectory(idx int, fi os.FileInfo, hdr *zip.FileHeader) error {
-	return a.writeEntry(idx, func() error {
+	return a.writeEntryNoWait(idx, func() error {
 		_, err := a.createHeader(fi, hdr)
 		incOnSuccess(&a.entries, err)
 		return err
@@ -278,7 +297,7 @@ func (a *Archiver) createSymlink(idx int, path string, fi os.FileInfo, hdr *zip.
 	hdr.UncompressedSize64 = hdr.CompressedSize64
 	hdr.CRC32 = crc32.ChecksumIEEE([]byte(link))
 
-	return a.writeEntry(idx, func() error {
+	return a.writeEntryNoWait(idx, func() error {
 		w, err := a.createHeaderRaw(fi, hdr)
 		if err != nil {
 			return err

--- a/archiver.go
+++ b/archiver.go
@@ -205,6 +205,13 @@ func (a *Archiver) Archive(ctx context.Context, files map[string]os.FileInfo) (e
 					err := a.createFile(ctx, entryIdx, path, fi, hdr, f)
 					fp.Put(f)
 					incOnSuccess(&a.entries, err)
+					if err != nil && a.order != nil {
+						// createFile can fail before it reaches its write turn
+						// (for example os.Open or a compression error), leaving
+						// the turn unconsumed. Abort so any later entry waiting on
+						// this one is released instead of blocking wg.Wait below.
+						a.order.abort()
+					}
 					return err
 				})
 			}

--- a/archiver_options.go
+++ b/archiver_options.go
@@ -12,11 +12,12 @@ var (
 type ArchiverOption func(*archiverOptions) error
 
 type archiverOptions struct {
-	method      uint16
-	concurrency int
-	bufferSize  int
-	stageDir    string
-	offset      int64
+	method          uint16
+	concurrency     int
+	bufferSize      int
+	stageDir        string
+	offset          int64
+	stableFileOrder bool
 }
 
 // WithArchiverMethod sets the zip method to be used for compressible files.
@@ -69,6 +70,24 @@ func WithStageDirectory(dir string) ArchiverOption {
 func WithArchiverOffset(n int64) ArchiverOption {
 	return func(o *archiverOptions) error {
 		o.offset = n
+		return nil
+	}
+}
+
+// WithStableFileOrder makes the archive output deterministic. Files are still
+// compressed concurrently, but their entries are written to the archive in the
+// order they were enumerated (sorted by name) rather than in the order their
+// compression happens to finish. The same set of input files then always
+// produces the same archive bytes, which is useful when the archive checksum is
+// compared across runs (for example, to detect that a retried upload carries an
+// identical archive).
+//
+// This can slightly reduce throughput when file compression times are uneven,
+// because a fast entry may have to wait for an earlier, slower one before it can
+// be flushed. It has no effect at a concurrency of 1, which is already ordered.
+func WithStableFileOrder() ArchiverOption {
+	return func(o *archiverOptions) error {
+		o.stableFileOrder = true
 		return nil
 	}
 }

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -191,6 +191,58 @@ func TestArchiveStableFileOrderIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestArchiveStableFileOrderFileErrorDoesNotDeadlock(t *testing.T) {
+	// A file that fails to open mid-archive must not strand later entries that
+	// are waiting for their write turn. The failing entry has a low index, so
+	// with stable ordering the higher-index entries block on it.
+	//
+	// The file count is kept at or below the concurrency, so the filepool never
+	// makes the dispatch loop block on Get. The loop finishes and reaches its
+	// final wg.Wait before the goroutines run, which is the case where the
+	// loop's own ctx cancellation check can no longer rescue a stranded turn.
+	testFiles := map[string]testFile{
+		"0_missing": {mode: 0666, contents: "gone"},
+	}
+	for i := 1; i < 8; i++ {
+		testFiles[fmt.Sprintf("%d_file", i)] = testFile{
+			mode:     0666,
+			contents: strings.Repeat("x", 4096),
+		}
+	}
+
+	files, dir := testCreateFiles(t, testFiles)
+	defer os.RemoveAll(dir)
+
+	// Remove the lowest-sorted file from disk while leaving it in the map, so
+	// os.Open fails for it during archiving.
+	require.NoError(t, os.Remove(filepath.Join(dir, "0_missing")))
+
+	done := make(chan error, 1)
+	go func() {
+		f, err := ioutil.TempFile("", "fastzip-deadlock")
+		if err != nil {
+			done <- err
+			return
+		}
+		defer os.Remove(f.Name())
+		defer f.Close()
+
+		a, err := NewArchiver(f, dir, WithArchiverConcurrency(16), WithStableFileOrder())
+		if err != nil {
+			done <- err
+			return
+		}
+		done <- a.Archive(context.Background(), files)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "expected the missing file to fail the archive")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Archive deadlocked on a file error with stable file order")
+	}
+}
+
 func TestArchiveCancelContext(t *testing.T) {
 	twoMB := strings.Repeat("1", 2*1024*1024)
 	testFiles := map[string]testFile{}

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -116,6 +116,7 @@ func TestArchive(t *testing.T) {
 		"with store":          {WithArchiverMethod(zip.Store)},
 		"with concurrency 2":  {WithArchiverConcurrency(2)},
 		"with stable order":   {WithArchiverConcurrency(4), WithStableFileOrder()},
+		"stable no buffer":    {WithArchiverConcurrency(4), WithArchiverBufferSize(0), WithStableFileOrder()},
 		"stable order store":  {WithArchiverMethod(zip.Store), WithStableFileOrder()},
 		"stable concurrency1": {WithArchiverConcurrency(1), WithStableFileOrder()},
 	}
@@ -221,6 +222,60 @@ func TestArchiveStableFileOrderIsDeterministic(t *testing.T) {
 	for i := 0; i < 25; i++ {
 		require.Equal(t, want, archiveSum(t, opts...), "archive checksum changed on run %d", i)
 	}
+
+	// A zero buffer size leaves no memory budget for queued writes, so every
+	// file entry waits for its turn instead. The bytes must not depend on
+	// which path was taken.
+	noBuffer := append([]ArchiverOption{WithArchiverBufferSize(0)}, opts...)
+	for i := 0; i < 5; i++ {
+		require.Equal(t, want, archiveSum(t, noBuffer...), "archive checksum differs without a memory budget on run %d", i)
+	}
+}
+
+func TestArchiveStableFileOrderFileGrownAfterStat(t *testing.T) {
+	// With stable ordering, a Store entry that isn't yet its turn is copied
+	// into memory using the size recorded at stat time. A file that grew since
+	// must still be archived whole.
+	testFiles := map[string]testFile{
+		"0_slow": {mode: 0666, contents: strings.Repeat("slow ", 200000)},
+	}
+	for i := 1; i < 8; i++ {
+		testFiles[fmt.Sprintf("%d_file", i)] = testFile{mode: 0666, contents: "short"}
+	}
+
+	files, dir := testCreateFiles(t, testFiles)
+	defer os.RemoveAll(dir)
+
+	grown := filepath.Join(dir, "4_file")
+	require.NoError(t, os.WriteFile(grown, []byte("short but then it grew"), 0666))
+
+	f, err := ioutil.TempFile("", "fastzip-grown")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	a, err := NewArchiver(f, dir, WithArchiverConcurrency(4), WithArchiverMethod(zip.Store), WithStableFileOrder())
+	require.NoError(t, err)
+	require.NoError(t, a.Archive(context.Background(), files))
+	require.NoError(t, a.Close())
+
+	b, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	zr, err := zip.NewReader(f, int64(len(b)))
+	require.NoError(t, err)
+	for _, zf := range zr.File {
+		if zf.Name != "4_file" {
+			continue
+		}
+		rc, err := zf.Open()
+		require.NoError(t, err)
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		require.NoError(t, rc.Close())
+		require.Equal(t, "short but then it grew", string(got))
+		return
+	}
+	t.Fatal("4_file not found in archive")
 }
 
 func TestArchiveStableFileOrderFileErrorDoesNotDeadlock(t *testing.T) {

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -164,9 +164,32 @@ func TestArchiveStableFileOrderIsDeterministic(t *testing.T) {
 			contents: strings.Repeat(fmt.Sprintf("content-%02d-", i), 1024*(i+1)),
 		}
 	}
+	// Directories interleaved with files in sorted order. Their writes are
+	// queued behind in-flight files rather than waited for, so this exercises
+	// that queued entries still land in the right place.
+	for i := 0; i < 20; i++ {
+		testFiles[fmt.Sprintf("tree/d%02d", i)] = testFile{mode: os.ModeDir | 0777}
+		testFiles[fmt.Sprintf("tree/d%02d/f", i)] = testFile{
+			mode:     0666,
+			contents: strings.Repeat(fmt.Sprintf("tree-%02d-", i), 512*(20-i)),
+		}
+	}
+	testFiles["tree"] = testFile{mode: os.ModeDir | 0777}
 
 	files, dir := testCreateFiles(t, testFiles)
 	defer os.RemoveAll(dir)
+
+	wantNames := make([]string, 0, len(files))
+	for name := range files {
+		rel, err := filepath.Rel(dir, name)
+		require.NoError(t, err)
+		rel = filepath.ToSlash(rel)
+		if files[name].IsDir() {
+			rel += "/"
+		}
+		wantNames = append(wantNames, rel)
+	}
+	sort.Strings(wantNames)
 
 	archiveSum := func(t *testing.T, opts ...ArchiverOption) [sha256.Size]byte {
 		f, err := ioutil.TempFile("", "fastzip-stable")
@@ -181,6 +204,15 @@ func TestArchiveStableFileOrderIsDeterministic(t *testing.T) {
 
 		b, err := os.ReadFile(f.Name())
 		require.NoError(t, err)
+
+		zr, err := zip.NewReader(f, int64(len(b)))
+		require.NoError(t, err)
+		gotNames := make([]string, 0, len(zr.File))
+		for _, zf := range zr.File {
+			gotNames = append(gotNames, zf.Name)
+		}
+		require.Equal(t, wantNames, gotNames, "entries not written in sorted order")
+
 		return sha256.Sum256(b)
 	}
 

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -2,6 +2,7 @@ package fastzip
 
 import (
 	"context"
+	"crypto/sha256"
 	"flag"
 	"fmt"
 	"io"
@@ -110,10 +111,13 @@ func TestArchive(t *testing.T) {
 	}
 
 	tests := map[string][]ArchiverOption{
-		"default options":    nil,
-		"no buffer":          {WithArchiverBufferSize(0)},
-		"with store":         {WithArchiverMethod(zip.Store)},
-		"with concurrency 2": {WithArchiverConcurrency(2)},
+		"default options":     nil,
+		"no buffer":           {WithArchiverBufferSize(0)},
+		"with store":          {WithArchiverMethod(zip.Store)},
+		"with concurrency 2":  {WithArchiverConcurrency(2)},
+		"with stable order":   {WithArchiverConcurrency(4), WithStableFileOrder()},
+		"stable order store":  {WithArchiverMethod(zip.Store), WithStableFileOrder()},
+		"stable concurrency1": {WithArchiverConcurrency(1), WithStableFileOrder()},
 	}
 
 	for tn, opts := range tests {
@@ -133,6 +137,57 @@ func TestArchive(t *testing.T) {
 				}
 			}, opts...)
 		})
+	}
+}
+
+func TestArchiveStableFileOrderIsDeterministic(t *testing.T) {
+	symMode := os.FileMode(0777)
+	if runtime.GOOS == "windows" {
+		symMode = 0666
+	}
+
+	// A mix of many compressible, incompressible, empty, symlink and directory
+	// entries, so that concurrent compression finishes in a different order
+	// from one run to the next. Without stable ordering the resulting archive
+	// bytes would vary; with it they must not.
+	testFiles := map[string]testFile{
+		"dir":        {mode: os.ModeDir | 0777},
+		"empty_dir":  {mode: os.ModeDir | 0777},
+		"symlink":    {mode: os.ModeSymlink | symMode, contents: "dir/file00"},
+		"incompress": {mode: 0666, contents: "A3#bez&OqCusPr)d&D]Vot9Eo0z^5O*VZm3:sO3HptL.H-4cOv"},
+		"empty_file": {mode: 0666},
+	}
+	for i := 0; i < 40; i++ {
+		name := fmt.Sprintf("dir/file%02d", i)
+		testFiles[name] = testFile{
+			mode:     0666,
+			contents: strings.Repeat(fmt.Sprintf("content-%02d-", i), 1024*(i+1)),
+		}
+	}
+
+	files, dir := testCreateFiles(t, testFiles)
+	defer os.RemoveAll(dir)
+
+	archiveSum := func(t *testing.T, opts ...ArchiverOption) [sha256.Size]byte {
+		f, err := ioutil.TempFile("", "fastzip-stable")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+		defer f.Close()
+
+		a, err := NewArchiver(f, dir, opts...)
+		require.NoError(t, err)
+		require.NoError(t, a.Archive(context.Background(), files))
+		require.NoError(t, a.Close())
+
+		b, err := os.ReadFile(f.Name())
+		require.NoError(t, err)
+		return sha256.Sum256(b)
+	}
+
+	opts := []ArchiverOption{WithArchiverConcurrency(8), WithStableFileOrder()}
+	want := archiveSum(t, opts...)
+	for i := 0; i < 25; i++ {
+		require.Equal(t, want, archiveSum(t, opts...), "archive checksum changed on run %d", i)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/saracen/fastzip
 
-go 1.22
+go 1.23
 
 require (
 	github.com/klauspost/compress v1.18.0

--- a/internal/filepool/filepool.go
+++ b/internal/filepool/filepool.go
@@ -13,7 +13,9 @@ import (
 
 var ErrPoolSizeLessThanZero = errors.New("pool size must be greater than zero")
 
-const defaultBufferSize = 2 * 1024 * 1024
+// DefaultBufferSize is the in-memory buffer size used by each pooled file when
+// a negative buffer size is requested.
+const DefaultBufferSize = 2 * 1024 * 1024
 
 type filePoolCloseError []error
 
@@ -58,7 +60,7 @@ func New(dir string, poolSize int, bufferSize int) (*FilePool, error) {
 	fp.limiter = make(chan int, poolSize)
 
 	if bufferSize < 0 {
-		bufferSize = defaultBufferSize
+		bufferSize = DefaultBufferSize
 	}
 
 	for i := range fp.files {

--- a/serializer.go
+++ b/serializer.go
@@ -21,13 +21,56 @@ type writeSerializer struct {
 
 	// pending holds writes registered with enqueue whose turn hasn't come yet.
 	// They run, in order, from whichever call advances next to their index.
-	pending map[int]func() error
+	pending map[int]pendingWrite
+
+	// pendingBytes is the total size of entry data held in memory by queued
+	// file writes; reserve refuses to exceed maxPendingBytes.
+	pendingBytes, maxPendingBytes int64
 }
 
-func newWriteSerializer() *writeSerializer {
-	s := &writeSerializer{pending: make(map[int]func() error)}
+// pendingWrite is a queued write and the in-memory budget it holds until run.
+type pendingWrite struct {
+	fn func() error
+	n  int64
+}
+
+func newWriteSerializer(maxPendingBytes int64) *writeSerializer {
+	s := &writeSerializer{pending: make(map[int]pendingWrite), maxPendingBytes: maxPendingBytes}
 	s.cond = sync.NewCond(&s.mu)
 	return s
+}
+
+// tryDo runs fn now if it is idx's turn and reports whether it ran.
+func (s *writeSerializer) tryDo(idx int, fn func() error) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.aborted {
+		return true, nil
+	}
+	if s.next != idx {
+		return false, nil
+	}
+	return true, s.run(fn, 0)
+}
+
+// reserve claims n bytes of the in-memory budget for a queued write. The
+// budget is returned when the write runs or the serializer is aborted, or by
+// release if the caller gives up before queueing it.
+func (s *writeSerializer) reserve(n int64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pendingBytes+n > s.maxPendingBytes {
+		return false
+	}
+	s.pendingBytes += n
+	return true
+}
+
+// release returns n bytes claimed with reserve that were never queued.
+func (s *writeSerializer) release(n int64) {
+	s.mu.Lock()
+	s.pendingBytes -= n
+	s.mu.Unlock()
 }
 
 // do blocks until it is idx's turn to write, runs fn while holding the write
@@ -51,7 +94,7 @@ func (s *writeSerializer) do(idx int, fn func() error) error {
 		return nil
 	}
 
-	return s.run(fn)
+	return s.run(fn, 0)
 }
 
 // enqueue registers a write that must not block the caller. If it is already
@@ -65,39 +108,48 @@ func (s *writeSerializer) do(idx int, fn func() error) error {
 // error is returned from whichever do or enqueue call ran it; since any error
 // aborts the archive, it doesn't matter which caller reports it.
 func (s *writeSerializer) enqueue(idx int, fn func() error) error {
+	return s.enqueueBytes(idx, 0, fn)
+}
+
+// enqueueBytes is enqueue for a write holding n bytes previously claimed with
+// reserve; the budget is returned once the write has run.
+func (s *writeSerializer) enqueueBytes(idx int, n int64, fn func() error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.aborted {
+		s.pendingBytes -= n
 		return nil
 	}
 
 	if s.next != idx {
-		s.pending[idx] = fn
+		s.pending[idx] = pendingWrite{fn, n}
 		return nil
 	}
 
-	return s.run(fn)
+	return s.run(fn, n)
 }
 
 // run executes fn as entry next, then drains consecutive pending entries.
 // The caller must hold s.mu.
-func (s *writeSerializer) run(fn func() error) error {
+func (s *writeSerializer) run(fn func() error, n int64) error {
 	defer s.cond.Broadcast()
 
 	for {
-		if err := fn(); err != nil {
+		err := fn()
+		s.pendingBytes -= n
+		if err != nil {
 			s.aborted = true
 			return err
 		}
 		s.next++
 
-		var ok bool
-		fn, ok = s.pending[s.next]
+		pw, ok := s.pending[s.next]
 		if !ok {
 			return nil
 		}
 		delete(s.pending, s.next)
+		fn, n = pw.fn, pw.n
 	}
 }
 

--- a/serializer.go
+++ b/serializer.go
@@ -1,0 +1,66 @@
+package fastzip
+
+import "sync"
+
+// writeSerializer enforces that zip entries are committed to the archive in the
+// order they were enumerated (sorted by name), regardless of the order their
+// concurrent compression finishes. This makes the archive output
+// deterministic: the same set of input files always produces the same bytes,
+// which lets callers rely on a stable archive checksum across repeated runs.
+//
+// It also provides the single-writer guarantee for the underlying zip.Writer,
+// so callers using it don't additionally lock Archiver.m.
+type writeSerializer struct {
+	mu      sync.Mutex
+	cond    *sync.Cond
+	next    int
+	aborted bool
+}
+
+func newWriteSerializer() *writeSerializer {
+	s := &writeSerializer{}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// do blocks until it is idx's turn to write, runs fn while holding the write
+// turn, then releases the turn to idx+1. Entries must present a contiguous
+// range of indices starting at 0; a missing index would stall every later
+// write.
+//
+// If fn returns an error, or the serializer has been aborted, all outstanding
+// and future writes are unblocked. A write cancelled by an abort returns nil,
+// because the entry itself didn't fail and the whole archive is discarded on
+// abort regardless; returning nil avoids masking the error that triggered the
+// teardown.
+func (s *writeSerializer) do(idx int, fn func() error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for s.next != idx && !s.aborted {
+		s.cond.Wait()
+	}
+
+	if s.aborted {
+		return nil
+	}
+
+	err := fn()
+	if err != nil {
+		s.aborted = true
+	}
+	s.next++
+	s.cond.Broadcast()
+
+	return err
+}
+
+// abort wakes every waiter so they return instead of blocking forever when the
+// archive is torn down before every entry has been dispatched (for example, an
+// error encountered while enumerating entries).
+func (s *writeSerializer) abort() {
+	s.mu.Lock()
+	s.aborted = true
+	s.cond.Broadcast()
+	s.mu.Unlock()
+}

--- a/serializer.go
+++ b/serializer.go
@@ -10,23 +10,29 @@ import "sync"
 //
 // It also provides the single-writer guarantee for the underlying zip.Writer,
 // so callers using it don't additionally lock Archiver.m.
+//
+// Entries must present a contiguous range of indices starting at 0; a missing
+// index would stall every later write.
 type writeSerializer struct {
 	mu      sync.Mutex
 	cond    *sync.Cond
 	next    int
 	aborted bool
+
+	// pending holds writes registered with enqueue whose turn hasn't come yet.
+	// They run, in order, from whichever call advances next to their index.
+	pending map[int]func() error
 }
 
 func newWriteSerializer() *writeSerializer {
-	s := &writeSerializer{}
+	s := &writeSerializer{pending: make(map[int]func() error)}
 	s.cond = sync.NewCond(&s.mu)
 	return s
 }
 
 // do blocks until it is idx's turn to write, runs fn while holding the write
-// turn, then releases the turn to idx+1. Entries must present a contiguous
-// range of indices starting at 0; a missing index would stall every later
-// write.
+// turn, then releases the turn to idx+1, running any enqueued writes that
+// immediately follow.
 //
 // If fn returns an error, or the serializer has been aborted, all outstanding
 // and future writes are unblocked. A write cancelled by an abort returns nil,
@@ -45,22 +51,63 @@ func (s *writeSerializer) do(idx int, fn func() error) error {
 		return nil
 	}
 
-	err := fn()
-	if err != nil {
-		s.aborted = true
-	}
-	s.next++
-	s.cond.Broadcast()
+	return s.run(fn)
+}
 
-	return err
+// enqueue registers a write that must not block the caller. If it is already
+// idx's turn, fn runs immediately, otherwise it is queued and run later by the
+// call that completes entry idx-1. This is for entries that hold no scarce
+// resource (directories, symlinks): the dispatch loop can register them and
+// keep dispatching files rather than waiting for every earlier file to finish
+// compressing.
+//
+// The returned error is fn's own error when it ran synchronously. A queued fn's
+// error is returned from whichever do or enqueue call ran it; since any error
+// aborts the archive, it doesn't matter which caller reports it.
+func (s *writeSerializer) enqueue(idx int, fn func() error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.aborted {
+		return nil
+	}
+
+	if s.next != idx {
+		s.pending[idx] = fn
+		return nil
+	}
+
+	return s.run(fn)
+}
+
+// run executes fn as entry next, then drains consecutive pending entries.
+// The caller must hold s.mu.
+func (s *writeSerializer) run(fn func() error) error {
+	defer s.cond.Broadcast()
+
+	for {
+		if err := fn(); err != nil {
+			s.aborted = true
+			return err
+		}
+		s.next++
+
+		var ok bool
+		fn, ok = s.pending[s.next]
+		if !ok {
+			return nil
+		}
+		delete(s.pending, s.next)
+	}
 }
 
 // abort wakes every waiter so they return instead of blocking forever when the
 // archive is torn down before every entry has been dispatched (for example, an
-// error encountered while enumerating entries).
+// error encountered while enumerating entries). Queued writes are dropped.
 func (s *writeSerializer) abort() {
 	s.mu.Lock()
 	s.aborted = true
+	s.pending = nil
 	s.cond.Broadcast()
 	s.mu.Unlock()
 }

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWriteSerializerOrdersWrites(t *testing.T) {
-	s := newWriteSerializer()
+	s := newWriteSerializer(0)
 
 	var got []int
 	record := func(i int) func() error {
@@ -48,7 +48,7 @@ func TestWriteSerializerOrdersWrites(t *testing.T) {
 }
 
 func TestWriteSerializerQueuedErrorAborts(t *testing.T) {
-	s := newWriteSerializer()
+	s := newWriteSerializer(0)
 	boom := errors.New("boom")
 
 	require.NoError(t, s.enqueue(1, func() error { return boom }))
@@ -65,7 +65,7 @@ func TestWriteSerializerQueuedErrorAborts(t *testing.T) {
 }
 
 func TestWriteSerializerAbortReleasesWaiters(t *testing.T) {
-	s := newWriteSerializer()
+	s := newWriteSerializer(0)
 
 	ran := false
 	done := make(chan error)
@@ -75,4 +75,28 @@ func TestWriteSerializerAbortReleasesWaiters(t *testing.T) {
 	s.abort()
 	require.NoError(t, <-done)
 	require.False(t, ran)
+}
+
+func TestWriteSerializerMemoryBudget(t *testing.T) {
+	s := newWriteSerializer(10)
+
+	require.True(t, s.reserve(6))
+	require.False(t, s.reserve(5), "over budget")
+	require.True(t, s.reserve(4))
+
+	// Budget is returned when a queued write runs, or when it is released
+	// without being queued.
+	require.NoError(t, s.enqueueBytes(1, 6, func() error { return nil }))
+	s.release(4)
+	require.False(t, s.reserve(5), "queued write still holds its bytes")
+
+	require.NoError(t, s.do(0, func() error { return nil }))
+	require.True(t, s.reserve(10), "budget returned after the queued write ran")
+	s.release(10)
+
+	// Queueing after an abort drops the write and returns its bytes.
+	s.abort()
+	require.True(t, s.reserve(10))
+	require.NoError(t, s.enqueueBytes(2, 10, func() error { return nil }))
+	require.Equal(t, int64(0), s.pendingBytes)
 }

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -1,0 +1,78 @@
+package fastzip
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteSerializerOrdersWrites(t *testing.T) {
+	s := newWriteSerializer()
+
+	var got []int
+	record := func(i int) func() error {
+		return func() error {
+			got = append(got, i)
+			return nil
+		}
+	}
+
+	// Queued entries wait for their predecessor and are drained, in order, by
+	// the call that completes it.
+	require.NoError(t, s.enqueue(1, record(1)))
+	require.NoError(t, s.enqueue(2, record(2)))
+	require.Empty(t, got)
+
+	require.NoError(t, s.do(0, record(0)))
+	require.Equal(t, []int{0, 1, 2}, got)
+
+	// An entry whose turn has already come runs immediately.
+	require.NoError(t, s.enqueue(3, record(3)))
+	require.Equal(t, []int{0, 1, 2, 3}, got)
+
+	// Blocked do calls resume in index order once the gap is filled.
+	var wg sync.WaitGroup
+	for _, i := range []int{6, 5} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, s.do(i, record(i)))
+		}()
+	}
+	require.NoError(t, s.enqueue(7, record(7)))
+	require.NoError(t, s.do(4, record(4)))
+	wg.Wait()
+	require.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7}, got)
+}
+
+func TestWriteSerializerQueuedErrorAborts(t *testing.T) {
+	s := newWriteSerializer()
+	boom := errors.New("boom")
+
+	require.NoError(t, s.enqueue(1, func() error { return boom }))
+
+	ran := false
+	require.NoError(t, s.enqueue(2, func() error { ran = true; return nil }))
+
+	// The queued failure surfaces from the call that drained it, and everything
+	// after it is skipped.
+	require.ErrorIs(t, s.do(0, func() error { return nil }), boom)
+	require.False(t, ran)
+	require.NoError(t, s.do(3, func() error { t.Fatal("ran after abort"); return nil }))
+	require.NoError(t, s.enqueue(4, func() error { t.Fatal("ran after abort"); return nil }))
+}
+
+func TestWriteSerializerAbortReleasesWaiters(t *testing.T) {
+	s := newWriteSerializer()
+
+	ran := false
+	done := make(chan error)
+	go func() { done <- s.do(1, func() error { ran = true; return nil }) }()
+	require.NoError(t, s.enqueue(2, func() error { ran = true; return nil }))
+
+	s.abort()
+	require.NoError(t, <-done)
+	require.False(t, ran)
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `WithStableFileOrder()` archiver option that makes the zip output deterministic: the same set of input files always produces the same archive bytes, and therefore the same checksum.

## Motivation

Today the archiver compresses files concurrently and writes each entry to the zip as soon as its compression finishes. That completion order is nondeterministic, so archiving the same directory twice yields different bytes even though the contents are identical.

We hit this in GitLab Runner: artifact uploads are retried on network failures by re-archiving from scratch, and GitLab's server-side idempotency check compares the archive `sha256` to recognize a retry of an already-stored artifact. Because each re-archive produced a different `sha256`, every retry looked like a brand new, conflicting artifact.

## What it does

Files are still compressed concurrently. Only the *write* of each entry is ordered: a small write serializer gates each entry on its enumeration index (the existing sorted order), so entries are committed in sorted order regardless of when their compression completes. The serializer also provides the single-writer guarantee that `Archiver.m` gave before.

- Opt-in and off by default; existing behavior is unchanged.
- No effect at concurrency 1, which is already ordered, and the serializer is not created in that case.
- Directories and symlinks hold no filepool slot, so their writes are queued rather than waited for. The dispatch loop never blocks on the serializer and files keep flowing through the pool. A queued write runs, in order, from whichever goroutine completes the entry before it.
- A file that finishes compressing before its turn copies its data out of the filepool slot and queues its write the same way, returning the slot at once. The copies are capped by a memory budget of concurrency × buffer size (16MB at the defaults); over budget the entry waits holding its slot. A zero buffer size disables the copies.
- Can reduce throughput when compression times are uneven, since entries behind a slow one wait for it.

## Notes on correctness

- The serializer is per `Archive` call and passed down the call chain, so concurrent `Archive` calls on one `Archiver` keep their own ordering. Every write still takes `Archiver.m`, which remains the single guard on the zip writer.
- The serializer releases its mutex while a write runs. Registering, queueing and aborting never wait for a write in progress, and a failing worker's error reaches the errgroup at once so its context cancellation stops that write at its next chunk.
- Skipped entries (irregular modes) are excluded before indices are assigned, so the serializer never stalls on a gap.
- On an early return (enumeration error, context cancellation), the serializer is aborted so any goroutine waiting for its turn is released rather than blocking `wg.Wait()`. A file entry that fails before reaching its write turn (for example `os.Open`) also aborts it.
- `Written()` counts a file entry once its bytes are in the zip, the same moment directories and symlinks are counted. Queued or aborted entries are not counted early.
- Pre-existing, also fixed here since the grown-file test exposed it: on the raw Deflate path a file that grew after enumeration kept its stat-time size in the headers while the stream covered the grown data, so readers rejected the entry. The size is now taken from the bytes actually compressed. This affected the default mode too.

## Performance

Real GitLab Runner artifact tree, the output of the `clone-gitlab-repo` job in https://gitlab.com/gitlab-org/gitlab/-/jobs/16454919549: 135,884 entries, 1.3GB, 24k directories, one 263MB git pack. Apple M-series, concurrency 8, best of 3 to 5 runs. The middle rows are earlier revisions of this PR.

| build | default | stable order |
|---|---|---|
| blocking directory writes | 2.64s | 5.85s |
| queued directory writes | 2.60s | 3.43s |
| plus queued small file writes (this PR) | 2.52s | 2.75s |

Profiling the 3.43s run showed 77% of samples in syscalls, two thirds of that in `open()`. Throughput on this tree tracks how many goroutines are opening files at once, and every goroutine parked on its write turn holding a pool slot is one fewer doing so. Freeing the slot recovers most of the gap. Budgets of 64MB and 256MB gave no further gain over 16MB.

Synthetic case, 300 directories with 3 × 256KB compressible files each:

| build | default | stable order |
|---|---|---|
| blocking directory writes | 20.3ms | 48.8ms |
| queued directory writes | 20.3ms | 21.4ms |

Default mode is unchanged. `BenchmarkArchiveStandardFlate_8` measured 341 MB/s on this branch vs 343 MB/s on `main`, within noise.

## Tests

- `TestArchiveStableFileOrderIsDeterministic` archives a mixed fileset, including 20 directories interleaved with files, many times at concurrency 8. It asserts the entries are in sorted order and that the `sha256` is stable across runs.
- `TestArchiveStableFileOrderFileErrorDoesNotDeadlock` covers a file failing to open with a low index while higher-index entries wait on it.
- `TestArchiveFileGrownAfterStat` covers Store and Deflate entries, with and without the option, whose file grew after enumeration.
- `TestArchiveStableFileOrderFileErrorDoesNotDeadlock` runs with a zero budget, where later entries really block on the failed one, and with the default budget, where they are queued and must be dropped.
- New: concurrent `Archive` calls on one `Archiver`, context cancellation at concurrency 4 with the option, and a skipped fifo between two files (unix only).
- The determinism test also runs with a zero buffer size and with a 1KB buffer size, so both the waiting and queued paths produce the same bytes.
- `serializer_test.go` covers queued drain order, error propagation from a queued write, abort releasing waiters, and memory budget accounting.
- `TestArchive` gains stable-order variants (concurrent, store, and concurrency 1) so the existing extraction/correctness assertions run with the option enabled.
- Full suite passes under `-race`.


